### PR TITLE
Object id and name properties for graph ql support

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 3.1.3
+* Exposing objectId and objectTemplateName getters as graphql does not allow accessing properties with underscores.
+
 ## 3.1.2
 * minor fix when checking for similar filters in schema definition.
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -167,10 +167,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             const time = getTime();
             let getQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.getFromPersistWithMongoId(template, id, cascade, isTransient, idMap, logger) :
-                PersistObjectTemplate.getFromPersistWithKnexId(template, id, cascade, isTransient, idMap, isRefresh, logger))
-                .then(function (res) {
-                    return res;
-                }.bind(this));
+                PersistObjectTemplate.getFromPersistWithKnexId(template, id, cascade, isTransient, idMap, isRefresh, logger));
 
             const name = 'getFromPersistWithId';
             return getQuery
@@ -209,10 +206,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
 
             let getQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.getFromPersistWithMongoQuery(template, query, cascade, start, limit, isTransient, idMap, options, logger) :
-                PersistObjectTemplate.getFromPersistWithKnexQuery(null, template, query, cascade, start, limit, isTransient, idMap, options, undefined, undefined, logger))
-                .then(function (res) {
-                    return res;
-                }.bind(this));
+                PersistObjectTemplate.getFromPersistWithKnexQuery(null, template, query, cascade, start, limit, isTransient, idMap, options, undefined, undefined, logger));
 
 
             const name = 'getFromPersistWithQuery';
@@ -384,10 +378,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             var dbType = PersistObjectTemplate.getDB(PersistObjectTemplate.getDBAlias(template.__collection__)).type;
             let countQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.countFromMongoQuery(template, query, logger) :
-                PersistObjectTemplate.countFromKnexQuery(template, query, logger))
-                .then(function (res) {
-                    return res;
-                }.bind(this));
+                PersistObjectTemplate.countFromKnexQuery(template, query, logger));
 
             const name = 'persistorCountByQuery';
             return countQuery
@@ -420,10 +411,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             var dbType = PersistObjectTemplate.getDB(PersistObjectTemplate.getDBAlias(template.__collection__)).type;
             let deleteQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.deleteFromPersistWithMongoId(template, id, logger) :
-                PersistObjectTemplate.deleteFromKnexId(template, id, txn, logger))
-                .then(function (res) {
-                    return res;
-                }.bind(this));
+                PersistObjectTemplate.deleteFromKnexId(template, id, txn, logger));
 
             const name = 'deleteFromPersistWithId';
             return deleteQuery
@@ -455,10 +443,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             var dbType = PersistObjectTemplate.getDB(PersistObjectTemplate.getDBAlias(template.__collection__)).type;
             let countQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.countFromMongoQuery(template, query, logger) :
-                PersistObjectTemplate.countFromKnexQuery(template, query, logger))
-                .then(function (res) {
-                    return res;
-                }.bind(this));
+                PersistObjectTemplate.countFromKnexQuery(template, query, logger));
 
             const name = 'countFromPersistWithQuery';
             return countQuery

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -756,7 +756,8 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
                 return this.__template__.countFromPersistWithQuery(
                     {
                         _id: (dbType == persistObjectTemplate.DB_Mongo) ? persistObjectTemplate.ObjectID(this._id.toString()) : this._id,
-                        __version__: this.__version__
+                        __version__: this.__version__,
+                        objectId: (dbType == persistObjectTemplate.DB_Mongo) ? persistObjectTemplate.ObjectID(this._id.toString()) : this._id
                     }).then(function (count) {
                         return !count
                     }.bind(this))
@@ -937,6 +938,22 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             let persistObjectTemplate = this.__objectTemplate__ || self;
             return (this._id = this._id || persistObjectTemplate.createPrimaryKey(this));
         };
+
+        Object.defineProperty(template.prototype, 'objectId', {
+            get: function () {
+                return this.generateId();
+            },
+            enumerable: true,
+            configurable: true
+        })
+
+        Object.defineProperty(template.prototype, 'objectTemplateName', {
+            get: function () {
+                return this._template;
+            },
+            enumerable: true,
+            configurable: true
+        })
 
         //persistorDelete will only support new API calls.
         template.prototype.persistorDelete = template.prototype.deleteV2 = async function (options) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -167,10 +167,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             const time = getTime();
             let getQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.getFromPersistWithMongoId(template, id, cascade, isTransient, idMap, logger) :
-                PersistObjectTemplate.getFromPersistWithKnexId(template, id, cascade, isTransient, idMap, isRefresh, logger))
-                .then(function (res) {
-                    return res;
-                }.bind(this));
+                PersistObjectTemplate.getFromPersistWithKnexId(template, id, cascade, isTransient, idMap, isRefresh, logger));
 
             const name = 'getFromPersistWithId';
             return getQuery
@@ -209,10 +206,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
 
             let getQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.getFromPersistWithMongoQuery(template, query, cascade, start, limit, isTransient, idMap, options, logger) :
-                PersistObjectTemplate.getFromPersistWithKnexQuery(null, template, query, cascade, start, limit, isTransient, idMap, options, undefined, undefined, logger))
-                .then(function (res) {
-                    return res;
-                }.bind(this));
+                PersistObjectTemplate.getFromPersistWithKnexQuery(null, template, query, cascade, start, limit, isTransient, idMap, options, undefined, undefined, logger));
 
 
             const name = 'getFromPersistWithQuery';
@@ -308,7 +302,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             let deleteQuery = dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.deleteFromPersistWithMongoQuery(template, query, options.logger) :
                 PersistObjectTemplate.deleteFromKnexByQuery(template, query, options.transaction, options.logger);
-
+            
             const name = 'persistorDeleteByQuery';
             return deleteQuery
                 .then(result => {
@@ -384,10 +378,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             var dbType = PersistObjectTemplate.getDB(PersistObjectTemplate.getDBAlias(template.__collection__)).type;
             let countQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.countFromMongoQuery(template, query, logger) :
-                PersistObjectTemplate.countFromKnexQuery(template, query, logger))
-                .then(function (res) {
-                    return res;
-                }.bind(this));
+                PersistObjectTemplate.countFromKnexQuery(template, query, logger));
 
             const name = 'persistorCountByQuery';
             return countQuery
@@ -420,10 +411,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             var dbType = PersistObjectTemplate.getDB(PersistObjectTemplate.getDBAlias(template.__collection__)).type;
             let deleteQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.deleteFromPersistWithMongoId(template, id, logger) :
-                PersistObjectTemplate.deleteFromKnexId(template, id, txn, logger))
-                .then(function (res) {
-                    return res;
-                }.bind(this));
+                PersistObjectTemplate.deleteFromKnexId(template, id, txn, logger));
 
             const name = 'deleteFromPersistWithId';
             return deleteQuery
@@ -455,10 +443,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             var dbType = PersistObjectTemplate.getDB(PersistObjectTemplate.getDBAlias(template.__collection__)).type;
             let countQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.countFromMongoQuery(template, query, logger) :
-                PersistObjectTemplate.countFromKnexQuery(template, query, logger))
-                .then(function (res) {
-                    return res;
-                }.bind(this));
+                PersistObjectTemplate.countFromKnexQuery(template, query, logger));
 
             const name = 'countFromPersistWithQuery';
             return countQuery

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -167,7 +167,10 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             const time = getTime();
             let getQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.getFromPersistWithMongoId(template, id, cascade, isTransient, idMap, logger) :
-                PersistObjectTemplate.getFromPersistWithKnexId(template, id, cascade, isTransient, idMap, isRefresh, logger));
+                PersistObjectTemplate.getFromPersistWithKnexId(template, id, cascade, isTransient, idMap, isRefresh, logger))
+                .then(function (res) {
+                    return res;
+                }.bind(this));
 
             const name = 'getFromPersistWithId';
             return getQuery
@@ -206,7 +209,10 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
 
             let getQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.getFromPersistWithMongoQuery(template, query, cascade, start, limit, isTransient, idMap, options, logger) :
-                PersistObjectTemplate.getFromPersistWithKnexQuery(null, template, query, cascade, start, limit, isTransient, idMap, options, undefined, undefined, logger));
+                PersistObjectTemplate.getFromPersistWithKnexQuery(null, template, query, cascade, start, limit, isTransient, idMap, options, undefined, undefined, logger))
+                .then(function (res) {
+                    return res;
+                }.bind(this));
 
 
             const name = 'getFromPersistWithQuery';
@@ -378,7 +384,10 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             var dbType = PersistObjectTemplate.getDB(PersistObjectTemplate.getDBAlias(template.__collection__)).type;
             let countQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.countFromMongoQuery(template, query, logger) :
-                PersistObjectTemplate.countFromKnexQuery(template, query, logger));
+                PersistObjectTemplate.countFromKnexQuery(template, query, logger))
+                .then(function (res) {
+                    return res;
+                }.bind(this));
 
             const name = 'persistorCountByQuery';
             return countQuery
@@ -411,7 +420,10 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             var dbType = PersistObjectTemplate.getDB(PersistObjectTemplate.getDBAlias(template.__collection__)).type;
             let deleteQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.deleteFromPersistWithMongoId(template, id, logger) :
-                PersistObjectTemplate.deleteFromKnexId(template, id, txn, logger));
+                PersistObjectTemplate.deleteFromKnexId(template, id, txn, logger))
+                .then(function (res) {
+                    return res;
+                }.bind(this));
 
             const name = 'deleteFromPersistWithId';
             return deleteQuery
@@ -443,7 +455,10 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             var dbType = PersistObjectTemplate.getDB(PersistObjectTemplate.getDBAlias(template.__collection__)).type;
             let countQuery = (dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.countFromMongoQuery(template, query, logger) :
-                PersistObjectTemplate.countFromKnexQuery(template, query, logger));
+                PersistObjectTemplate.countFromKnexQuery(template, query, logger))
+                .then(function (res) {
+                    return res;
+                }.bind(this));
 
             const name = 'countFromPersistWithQuery';
             return countQuery

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -946,6 +946,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             configurable: true
         })
 
+        
         Object.defineProperty(template.prototype, 'objectTemplateName', {
             get: function () {
                 return this._template;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -756,8 +756,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
                 return this.__template__.countFromPersistWithQuery(
                     {
                         _id: (dbType == persistObjectTemplate.DB_Mongo) ? persistObjectTemplate.ObjectID(this._id.toString()) : this._id,
-                        __version__: this.__version__,
-                        objectId: (dbType == persistObjectTemplate.DB_Mongo) ? persistObjectTemplate.ObjectID(this._id.toString()) : this._id
+                        __version__: this.__version__
                     }).then(function (count) {
                         return !count
                     }.bind(this))

--- a/lib/knex/db.ts
+++ b/lib/knex/db.ts
@@ -247,7 +247,10 @@ module.exports = function (PersistObjectTemplate) {
         return knex.delete();
     };
 
-    PersistObjectTemplate.deleteFromKnexByQuery = function (template, queryOrChains, txn, _logger) {
+    PersistObjectTemplate.deleteFromKnexByQuery = async function (template, queryOrChains, txn, _logger) {
+        if (!txn) {
+            return PersistObjectTemplate.deleteFromKnexQuery(template, queryOrChains, txn, _logger);
+        }
         var deleteQueries = txn ? txn.deleteQueries : this.deleteQueries;
         var deleteQuery = {name: template.__name__, template: template, queryOrChains: queryOrChains};
         deleteQueries[template.__name__] = deleteQuery;

--- a/lib/persistable.ts
+++ b/lib/persistable.ts
@@ -71,6 +71,10 @@ export function Persistable<BC extends Constructable<{}>>(Base: BC) {
         persistorIsStale () : any {}
         generateId() : any {};
 
+        
+        objectId : string ;
+        objectTemplateName : string ;
+        
         _id: string;
         __version__: number;
         amorphic : Persistor;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@havenlife/persistor",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@havenlife/persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from mongodb",
     "homepage": "https://github.com/haven-life/persistor",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {

--- a/test/persist_banking.js
+++ b/test/persist_banking.js
@@ -660,8 +660,9 @@ describe('Banking Example JS', function () {
         writing = true;
         var testDelete = new Customer('Ashling', '', 'testDelete');
         return testDelete.persistSave()
-            .then(Customer.countFromPersistWithQuery.bind(this))
-            .then(function(count) {
+            .then(function() {
+                return Customer.countFromPersistWithQuery();
+            }).then(function(count) {
                 expect(count).to.equal(5);
             }).then(function() {
                 return Customer.deleteFromPersistWithQuery({lastName: {$eq: 'testDelete'}})

--- a/test/persist_banking.js
+++ b/test/persist_banking.js
@@ -241,7 +241,7 @@ function clearCollection(collectionName) {
     });
 }
 
-describe('Banking Example', function () {
+describe('Banking Example JS', function () {
     after('close db connection', function() {
         return db.close();
     });
@@ -689,7 +689,7 @@ describe('Banking Example', function () {
         return PersistObjectTemplate.getTemplateFromMongoPOJO(pojo, withoutType, null, null, {});
     });
 
-    it('can delete', function (done) {
+    it('can delete persist_banking', function (done) {
         Customer.getFromPersistWithId(sam._id,
             {roles: {fetch: {account: {fetch: {roles: {fetch: {customer: {fetch: true}}}}}}}}).then (function (customer) {
                 var promises = [];

--- a/test/persist_banking_pgsql.js
+++ b/test/persist_banking_pgsql.js
@@ -1183,7 +1183,7 @@ describe('Banking from pgsql Example', function () {
     });
 
 
-    it('can delete', function (done) {
+    it('can delete js', function (done) {
         Customer.getFromPersistWithQuery({}, {roles: {fetch: {account: true}}}).then (function (customers) {
             function deleteStuff(txn) {
                 var promises = [];

--- a/test/persist_newapi_tests.js
+++ b/test/persist_newapi_tests.js
@@ -511,4 +511,26 @@ describe('persistor transaction checks', function () {
             return knex.raw('ALTER TABLE public.tx_employee ADD CONSTRAINT fk_tx_employee_address FOREIGN KEY (address_id) references public.tx_address("_id") deferrable initially deferred');
         }
     });
+
+    it('calling delete without transaction', function () {
+        return createFKs()
+            .then(loadEmployee.bind(this))
+            .then(realTest.bind(this));
+
+        function loadEmployee() {
+            return Employee.persistorFetchById(empId, {fetch: {homeAddress: true}})
+        }
+
+        async function realTest() {
+            await Promise.all([Employee.persistorDeleteByQuery({name: 'Ravi'}),
+            Address.persistorDeleteByQuery({city: 'New York'})]);
+            return Employee.persistorFetchByQuery({name: 'Ravi'}).then(function(employees) {
+                expect(employees.length).to.equal(0);
+            })
+        }
+
+        function createFKs() {
+            return knex.raw('ALTER TABLE public.tx_employee ADD CONSTRAINT fk_tx_employee_address FOREIGN KEY (address_id) references public.tx_address("_id") deferrable initially deferred');
+        }
+    });
 });

--- a/test/persist_newapi_tests.js
+++ b/test/persist_newapi_tests.js
@@ -522,8 +522,8 @@ describe('persistor transaction checks', function () {
         }
 
         async function realTest() {
-            await Promise.all([Employee.persistorDeleteByQuery({name: 'Ravi'}),
-            Address.persistorDeleteByQuery({city: 'New York'})]);
+            await Employee.persistorDeleteByQuery({name: 'Ravi'});
+            
             return Employee.persistorFetchByQuery({name: 'Ravi'}).then(function(employees) {
                 expect(employees.length).to.equal(0);
             })

--- a/test/persist_newapi_tests.js
+++ b/test/persist_newapi_tests.js
@@ -523,7 +523,6 @@ describe('persistor transaction checks', function () {
 
         async function realTest() {
             await Employee.persistorDeleteByQuery({name: 'Ravi'});
-            
             return Employee.persistorFetchByQuery({name: 'Ravi'}).then(function(employees) {
                 expect(employees.length).to.equal(0);
             })

--- a/test/persist_transaction.js
+++ b/test/persist_transaction.js
@@ -329,7 +329,7 @@ describe('persistor transaction checks', function () {
         expect(Object.keys(tx.dirtyObjects).length).to.equal(0);
     });
 
-    it('when an array of field used without providing the table name..', function () {
+    it('when an array of fields used without providing the table name..', function () {
         schema.EmployeeDelWithoutTable = {};
         schema.AddressDelWithoutTable = {};
         schema.EmployeeDelWithoutTable.documentOf = 'tx_deletewot_employee';
@@ -361,7 +361,7 @@ describe('persistor transaction checks', function () {
         })
     });
 
-    it('when an array of field used without providing the table name..', function () {
+    it('when an array of fields used without providing the table name 2..', function () {
         schema.EmployeeDelWithoutTable1 = {};
         schema.AddressDelWithoutTable1 = {};
         schema.EmployeeDelWithoutTable1.table = 'tx_deletewot1_employee';

--- a/test/persist_transaction.js
+++ b/test/persist_transaction.js
@@ -329,7 +329,7 @@ describe('persistor transaction checks', function () {
         expect(Object.keys(tx.dirtyObjects).length).to.equal(0);
     });
 
-    it('when an array of fields used without providing the table name..', function () {
+    it('when an array of fields are used without providing the table name..', function () {
         schema.EmployeeDelWithoutTable = {};
         schema.AddressDelWithoutTable = {};
         schema.EmployeeDelWithoutTable.documentOf = 'tx_deletewot_employee';
@@ -361,7 +361,7 @@ describe('persistor transaction checks', function () {
         })
     });
 
-    it('when an array of fields used without providing the table name 2..', function () {
+    it('when an array of fields are used without providing the table name 2..', function () {
         schema.EmployeeDelWithoutTable1 = {};
         schema.AddressDelWithoutTable1 = {};
         schema.EmployeeDelWithoutTable1.table = 'tx_deletewot1_employee';

--- a/test/supertype/persist_banking_pgsql.ts
+++ b/test/supertype/persist_banking_pgsql.ts
@@ -971,7 +971,7 @@ describe('Banking from pgsql Example', function () {
     });
 
 
-    it('can delete', function (done) {
+    it('can delete ts', function (done) {
         Customer.getFromPersistWithQuery({}, {roles: {fetch: {account: {fetch: {roles: true}}}}}).then (function (customers) {
             function deleteStuff(txn) {
                 var promises = [];


### PR DESCRIPTION
Simple change to expose objectId and objectTemplateName properties, so that graphQL endpoints can directly get these values if requested from the client.