### PR TITLE
Switch from forEach loop by switching to "for of..."

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 3.1.4
+* Fix bad promise handling in a forEach loop by switching to "for of..."
+
 ## 3.1.3
 * Exposing objectId and objectTemplateName getters as graphql does not allow accessing properties with underscores.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@havenlife/persistor",
-    "version": "3.1.3",
+    "version": "3.1.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@havenlife/persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from mongodb",
     "homepage": "https://github.com/haven-life/persistor",
-    "version": "3.1.3",
+    "version": "3.1.4",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {


### PR DESCRIPTION
We have seen the following stacktrace when attempt to fetch data 

```Cannot read property 'bucket' of undefined TypeError: Cannot read property 'bucket' of undefined\n at /opt/haven/app/node_modules/@havenlife/persistor/dist/lib/knex/query.js:420:47\n at /opt/haven/app/node_modules/underscore/underscore.js:188:11\n at Function..each..forEach (/opt/haven/app/node_modules/underscore/underscore.js:103:9)\n at Function..filter..select```.

Investigating further this is bad promise handling in line 420 of query.js, with using the async pattern in a forEach loop. Fixing it to for of...resolved the problem 