### PR TITLE
fix rollback behavior + edit auth method for aws

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
+## 3.2.2
+* updating order of operations for multisource rollbacks
+* fixing default method of authentication with aws
 ## 3.2.1
 * changing field returned for objectTemplateName to make sure it is returned even when object is not persisted
-
 ## 3.2.0
 * enable remote storage of data properties (knex path only).
 * local FS and amazon S3 supported out of the box for non-db storage location.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@havenlife/persistor",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@havenlife/persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from mongodb",
     "homepage": "https://github.com/haven-life/persistor",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {


### PR DESCRIPTION
- assume that the consumer wants to use the aws concept of roles for auth instead of handling creds explicitly
- tighten rollback failure scenarios